### PR TITLE
Missed one instance of verma

### DIFF
--- a/ECOv003_L3T_L4T_JET/ECOv003_L3T_L4T_JET.py
+++ b/ECOv003_L3T_L4T_JET/ECOv003_L3T_L4T_JET.py
@@ -693,7 +693,7 @@ def L3T_L4T_JET(
         Rn_daily = daily_Rn_integration_verma(
             Rn=Rn,
             hour_of_day=hour_of_day,
-            doy=day_of_year,
+            DOY=day_of_year,
             lat=geometry.lat,
         )
 


### PR DESCRIPTION
It turns out it's called twice in JET's main function.

Missed one in #48 